### PR TITLE
update composer.json to allow install on oro >2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "oro/platform": "2.1.*"
+        "oro/platform": "^2.1"
     },
     "autoload": {
         "psr-0": { "Aligent\\LiveChatBundle": "." },


### PR DESCRIPTION
The platform version needs to be updated in the composer.json to allow installs on oro >2.1